### PR TITLE
Update "See More" text to use GatsbyLink

### DIFF
--- a/src/components/post.js
+++ b/src/components/post.js
@@ -112,7 +112,11 @@ const Post = ({ summary, mentions, post, previous, next }) => {
         {summary ? (
           <>
             <p>{excerpt}</p>
-            <Link to={postPath} className={style.readMore}>
+            <Link
+              as={GatsbyLink}
+              to={postPath}
+              className={style.readMore}
+            >
               Read more →
             </Link>
           </>


### PR DESCRIPTION
Just noticed that I couldn't actually click on your text here. I think it is just because you're using relative paths which are 💖  and just wanna keep the ✨.

I had difficulty testing this locally due to TakeShape but let me know if this works for you.