### PR TITLE
Send resend events to PostHog

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "pluralize": "^8.0.0",
     "postcss": "^8.4.41",
     "posthog-js": "^1.155.4",
+    "posthog-node": "^4.1.0",
     "prism-react-renderer": "^2.3.1",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       posthog-js:
         specifier: ^1.155.4
         version: 1.155.4
+      posthog-node:
+        specifier: ^4.1.0
+        version: 4.1.0
       prism-react-renderer:
         specifier: ^2.3.1
         version: 2.3.1(react@18.3.1)
@@ -1400,9 +1403,6 @@ packages:
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
-  '@types/eslint@8.56.11':
-    resolution: {integrity: sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==}
-
   '@types/eslint@9.6.0':
     resolution: {integrity: sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==}
 
@@ -1742,6 +1742,9 @@ packages:
     resolution: {integrity: sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==}
     hasBin: true
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autoprefixer@10.4.20:
     resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1756,6 +1759,9 @@ packages:
   axe-core@4.9.1:
     resolution: {integrity: sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==}
     engines: {node: '>=4'}
+
+  axios@1.7.4:
+    resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
 
   axobject-query@3.1.1:
     resolution: {integrity: sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==}
@@ -1878,6 +1884,10 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -2010,6 +2020,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -2393,6 +2407,15 @@ packages:
   flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
 
+  follow-redirects@1.15.6:
+    resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
@@ -2403,6 +2426,10 @@ packages:
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -3412,6 +3439,10 @@ packages:
   posthog-js@1.155.4:
     resolution: {integrity: sha512-suxwAsmZGqMDXJe/RaCKI3PaDEHiuMDDhKcJklgGAg7eDnywieRkr5CoPcOOvnqTDMnuOPETr98jpYBXKUwGFQ==}
 
+  posthog-node@4.1.0:
+    resolution: {integrity: sha512-Fd+aMWLjUttlPrfOniDWs35v62rOEIqP5GBzUvRswsNY8rr1g1KuDobqaRFGMCNnrtDmhzUN8y7QucrcwMY/+w==}
+    engines: {node: '>=15.0.0'}
+
   preact@10.23.2:
     resolution: {integrity: sha512-kKYfePf9rzKnxOAKDpsWhg/ysrHPqT+yQ7UW4JjdnqjFIeNUnNcEJvhuA8fDenxAGWzUqtd51DfVg7xp/8T9NA==}
 
@@ -3492,6 +3523,9 @@ packages:
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3623,6 +3657,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rusha@0.8.14:
+    resolution: {integrity: sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA==}
 
   safe-array-concat@1.1.0:
     resolution: {integrity: sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==}
@@ -5802,13 +5839,8 @@ snapshots:
 
   '@types/eslint-scope@3.7.7':
     dependencies:
-      '@types/eslint': 8.56.11
+      '@types/eslint': 9.6.0
       '@types/estree': 1.0.5
-
-  '@types/eslint@8.56.11':
-    dependencies:
-      '@types/estree': 1.0.5
-      '@types/json-schema': 7.0.15
 
   '@types/eslint@9.6.0':
     dependencies:
@@ -6231,6 +6263,8 @@ snapshots:
 
   astring@1.8.6: {}
 
+  asynckit@0.4.0: {}
+
   autoprefixer@10.4.20(postcss@8.4.41):
     dependencies:
       browserslist: 4.23.3
@@ -6246,6 +6280,14 @@ snapshots:
       possible-typed-array-names: 1.0.0
 
   axe-core@4.9.1: {}
+
+  axios@1.7.4:
+    dependencies:
+      follow-redirects: 1.15.6
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axobject-query@3.1.1:
     dependencies:
@@ -6369,6 +6411,10 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
 
@@ -6495,6 +6541,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   depd@1.1.2: {}
 
@@ -7092,6 +7140,8 @@ snapshots:
 
   flatted@3.3.1: {}
 
+  follow-redirects@1.15.6: {}
+
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -7105,6 +7155,12 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
+
+  form-data@4.0.0:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   fraction.js@4.3.7: {}
 
@@ -8383,6 +8439,13 @@ snapshots:
       preact: 10.23.2
       web-vitals: 4.2.3
 
+  posthog-node@4.1.0:
+    dependencies:
+      axios: 1.7.4
+      rusha: 0.8.14
+    transitivePeerDependencies:
+      - debug
+
   preact@10.23.2: {}
 
   prelude-ls@1.2.1: {}
@@ -8410,6 +8473,8 @@ snapshots:
   property-information@6.4.1: {}
 
   proto-list@1.2.4: {}
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 
@@ -8651,6 +8716,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rusha@0.8.14: {}
 
   safe-array-concat@1.1.0:
     dependencies:

--- a/src/pages/api/inbound_webhooks/resend.ts
+++ b/src/pages/api/inbound_webhooks/resend.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from 'http';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { buffer } from 'micro';
+import { PostHog } from 'posthog-node';
 import { Webhook } from 'svix';
 import type { WebhookRequiredHeaders } from 'svix';
 
@@ -8,9 +9,17 @@ import { env } from '@utils/env';
 import {
   ContactEvents,
   EmailEvents,
+  isContactEvent,
+  isEmailEvent,
   sendSubscriberNotificationEmail,
 } from '@utils/resend';
 import type { ContactEventData, WebhookEvent } from '@utils/resend';
+
+const ph = new PostHog(env.NEXT_PUBLIC_POSTHOG_KEY, {
+  host: 'https://us.i.posthog.com',
+  flushAt: 1, // flush immediately since this is a serverless function
+  flushInterval: 0, // disable periodic flush as well
+});
 
 const webhook = new Webhook(env.RESEND_SIGNING_SECRET);
 
@@ -44,17 +53,38 @@ const webhooks = async (req: NextApiRequest, res: NextApiResponse) => {
     // Verify the webhook signature and extract the event
     const event = webhook.verify(payload, headers) as WebhookEvent;
 
-    // Make sure this webhook is for the current audience.
-    // This site uses distinct Resend audiences
-    // for localdev / CI vs production, so we need to
-    // check the audience ID in the event data before processing.
-    if (event.type in ContactEvents) {
+    if (isEmailEvent(event)) {
+      const id = Array.isArray(event.data.to)
+        ? event.data.to[0]
+        : event.data.to;
+      ph.capture({
+        distinctId: id,
+        event: `resend/${event.type}`,
+        properties: event.data,
+      });
+      ph.flush();
+    }
+
+    if (isContactEvent(event)) {
+      // Make sure this webhook is for the current audience.
+      // This site uses distinct Resend audiences
+      // for localdev / CI vs production, so we need to
+      // check the audience ID in the event data before processing.
       if (!ensureEventForCurrentAudience(event.data as ContactEventData)) {
         return res.status(200).end();
       }
+
+      // Track the contact event in PostHog
+      ph.capture({
+        distinctId: event.data.email ?? event.data.id,
+        event: `resend/${event.type}`,
+        properties: event.data,
+      });
+      ph.flush();
     }
 
     switch (event.type) {
+      // Contact events
       case ContactEvents.ContactCreated:
         try {
           // fire off an email to to myself!
@@ -66,8 +96,9 @@ const webhooks = async (req: NextApiRequest, res: NextApiResponse) => {
         break;
       case ContactEvents.ContactDeleted:
       case ContactEvents.ContactUpdated:
-        console.log('Unhandled contact event:', event);
         break;
+
+      // Email events
       case EmailEvents.EmailBounced:
       case EmailEvents.EmailClicked:
       case EmailEvents.EmailComplained:
@@ -75,7 +106,6 @@ const webhooks = async (req: NextApiRequest, res: NextApiResponse) => {
       case EmailEvents.EmailDeliveryDelayed:
       case EmailEvents.EmailOpened:
       case EmailEvents.EmailSent:
-        console.log('Unhandled email event:', event);
         break;
       default:
         console.log('Unknown event type:', event);
@@ -86,6 +116,10 @@ const webhooks = async (req: NextApiRequest, res: NextApiResponse) => {
   } catch (error) {
     res.status(400).send(error);
     return;
+  } finally {
+    // see https://github.com/PostHog/posthog/issues/13092#issuecomment-1342966441
+    await ph.shutdown();
+    await new Promise((r) => setTimeout(r, 500));
   }
 };
 

--- a/src/pages/api/inbound_webhooks/resend.ts
+++ b/src/pages/api/inbound_webhooks/resend.ts
@@ -62,7 +62,7 @@ const webhooks = async (req: NextApiRequest, res: NextApiResponse) => {
         event: `resend/${event.type}`,
         properties: event.data,
       });
-      ph.flush();
+      await ph.flush();
     }
 
     if (isContactEvent(event)) {
@@ -70,7 +70,7 @@ const webhooks = async (req: NextApiRequest, res: NextApiResponse) => {
       // This site uses distinct Resend audiences
       // for localdev / CI vs production, so we need to
       // check the audience ID in the event data before processing.
-      if (!ensureEventForCurrentAudience(event.data as ContactEventData)) {
+      if (!ensureEventForCurrentAudience(event.data)) {
         return res.status(200).end();
       }
 
@@ -80,7 +80,7 @@ const webhooks = async (req: NextApiRequest, res: NextApiResponse) => {
         event: `resend/${event.type}`,
         properties: event.data,
       });
-      ph.flush();
+      await ph.flush();
     }
 
     switch (event.type) {

--- a/src/utils/resend.ts
+++ b/src/utils/resend.ts
@@ -70,18 +70,42 @@ export type ContactEventData = {
 };
 
 export type EmailEvent = {
-  created_at: string;
   type: EmailEventType;
   data: EmailEventData;
 };
 
 export type ContactEvent = {
-  created_at: string;
   type: ContactEventType;
   data: ContactEventData;
 };
 
 export type WebhookEvent = EmailEvent | ContactEvent;
+
+export function isContactEvent(event: WebhookEvent): event is ContactEvent {
+  if (
+    event.type === ContactEvents.ContactCreated ||
+    event.type === ContactEvents.ContactUpdated ||
+    event.type === ContactEvents.ContactDeleted
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function isEmailEvent(event: WebhookEvent): event is EmailEvent {
+  if (
+    event.type === EmailEvents.EmailBounced ||
+    event.type === EmailEvents.EmailClicked ||
+    event.type === EmailEvents.EmailComplained ||
+    event.type === EmailEvents.EmailDelivered ||
+    event.type === EmailEvents.EmailDeliveryDelayed ||
+    event.type === EmailEvents.EmailOpened ||
+    event.type === EmailEvents.EmailSent
+  ) {
+    return true;
+  }
+  return false;
+}
 
 const EmailTags: Record<string, Tag> = {
   SubscriberNotification: {


### PR DESCRIPTION
This pull request adds functionality to send resend events to PostHog. It includes changes to the code that allow for tracking contact and email events in PostHog. The events are captured and sent to PostHog using the PostHog Node.js library. This will enable better tracking and analysis of resend events in PostHog.