### PR TITLE
Remove author from FullPost component and BlogPost type

### DIFF
--- a/src/components/Post/FullPost.tsx
+++ b/src/components/Post/FullPost.tsx
@@ -23,7 +23,6 @@ const FullPost: React.FC<FullPostProps> = ({ post }) => {
   const { frontmatter } = post;
 
   const {
-    author,
     coverImagePublicId,
     date,
     excerpt,
@@ -87,7 +86,7 @@ const FullPost: React.FC<FullPostProps> = ({ post }) => {
               {title}
             </Heading>
             <p className="text-xs text-gray-700 dark:text-gray-400">
-              <PublishDate date={date} /> {author && <>— Written by {author}</>}
+              <PublishDate date={date} />{' '}
             </p>
 
             <TagsSummary tags={tags} />

--- a/src/data/content-types.ts
+++ b/src/data/content-types.ts
@@ -49,7 +49,6 @@ export type BlogPost = MarkdownDocument & {
     date: string;
     excerpt: string;
     content: string;
-    author?: string;
     coverImagePublicId: string;
     published: boolean;
     path: string;


### PR DESCRIPTION
This pull request removes the "author" field from the FullPost component and the BlogPost type. The "author" field is no longer needed and has been removed from both the component and the type definition.