### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Test - E2E
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/mbifulco/blog/security/code-scanning/10](https://github.com/mbifulco/blog/security/code-scanning/10)

To address this, add a `permissions` key to either the root of the workflow or specifically to the `playwright` job (since only one job exists, the effect is the same). The minimal and safest explicit setting is `permissions: contents: read`, which gives the steps access to the repository code without additional write capabilities. This should be added directly after the workflow `name` at the root, or after the `playwright` job name. Since there is only one job, adding it at the workflow level is clearer, easier to audit, and covers any future jobs as well.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
