### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint and Dependency Checks
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/mbifulco/blog/security/code-scanning/6](https://github.com/mbifulco/blog/security/code-scanning/6)

To fix the issue, explicitly declare the least required privileges using the `permissions:` key. Since the workflow only checks out code and runs linting/dependency tools, it only needs read access to the repository contents. Add `permissions: contents: read` at either the root level of the workflow (applies to all jobs), or at the `lint` job level (applies only to that job). The best-practice, most maintainable way is to add it at the root level―immediately after the `name:` entry and before `on:`―so all future jobs in this workflow inherit these reduced privileges unless overridden.

You only need to add:

```yaml
permissions:
  contents: read
```

No imports or definitions are needed. Add this block after the `name: Lint and Dependency Checks` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
