### PR TITLE
feat: count markdown twin and llms.txt requests in PostHog and Fathom

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,9 @@ RESEND_SIGNING_SECRET=test
 # Create a free Redis database at https://upstash.com
 UPSTASH_REDIS_REST_URL=https://your-redis.upstash.io
 UPSTASH_REDIS_REST_TOKEN=your-token-here
+
+# Server-side analytics for the markdown twins and llms.txt files, which run no
+# client-side JS. auto (default) = production deployments only | on | off
+SERVER_ANALYTICS=auto
+# Kill switch for the server-side Fathom beacon alone. on (default) | off
+FATHOM_SERVER_BEACON=on

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,35 @@
+import { test as base, expect } from '@playwright/test';
+
+/** Session key `useNewsletterModalTrigger` checks before opening the modal. */
+const MODAL_SHOWN_KEY = 'newsletter_modal_shown';
+
+/**
+ * The base Playwright `test` with the newsletter modal kept shut.
+ *
+ * `useNewsletterModalTrigger` opens the modal once a visitor passes 50% scroll
+ * depth (or sits on a page for 30 seconds). Playwright scrolls elements into
+ * view before clicking them, so reaching anything near the bottom of a page —
+ * the pagination controls, say — trips that trigger, and the modal's overlay
+ * then swallows the click. Whether the click or the modal wins is a race, which
+ * is why it only failed on slower CI runs.
+ *
+ * Seeding the "already shown" flag puts every test in the same position as a
+ * reader who has seen the modal earlier in the session. Tests that want the
+ * modal should import `test` from `@playwright/test` directly and clear it.
+ */
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.addInitScript((key) => {
+      try {
+        window.sessionStorage.setItem(key, 'true');
+      } catch {
+        // sessionStorage is unavailable on some origins; the modal is not the
+        // thing under test, so a failure here should not fail the test.
+      }
+    }, MODAL_SHOWN_KEY);
+
+    await use(page);
+  },
+});
+
+export { expect };

--- a/e2e/markdown-routes.spec.ts
+++ b/e2e/markdown-routes.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 test.describe('markdown routes', () => {
   test('serves a post as markdown', async ({ request }) => {

--- a/e2e/newsletter-signup.spec.ts
+++ b/e2e/newsletter-signup.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 test.describe('Newsletter Signup Page', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/pagination.spec.ts
+++ b/e2e/pagination.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 test.describe('Pagination', () => {
   test.describe('Home page pagination', () => {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures';
 
 test('home page smoke test', async ({ page }) => {
   await page.goto('/');

--- a/src/lib/analytics/content-requests.test.ts
+++ b/src/lib/analytics/content-requests.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyContentRequest,
+  TRACKED_CONTENT_MATCHERS,
+} from './content-requests';
+
+describe('classifyContentRequest', () => {
+  it('identifies a post markdown twin', () => {
+    expect(classifyContentRequest('/posts/all-about-ch.md')).toEqual({
+      format: 'markdown',
+      contentType: 'posts',
+      slug: 'all-about-ch',
+      path: '/posts/all-about-ch.md',
+    });
+  });
+
+  it('identifies a newsletter markdown twin', () => {
+    expect(
+      classifyContentRequest('/newsletter/you-are-not-your-user.md')
+    ).toEqual({
+      format: 'markdown',
+      contentType: 'newsletter',
+      slug: 'you-are-not-your-user',
+      path: '/newsletter/you-are-not-your-user.md',
+    });
+  });
+
+  it('identifies the llms.txt files', () => {
+    expect(classifyContentRequest('/llms.txt')?.format).toBe('llms-index');
+    expect(classifyContentRequest('/llms-full.txt')?.format).toBe('llms-full');
+  });
+
+  it('ignores the html pages the twins mirror', () => {
+    expect(classifyContentRequest('/posts/all-about-ch')).toBeNull();
+    expect(classifyContentRequest('/newsletter')).toBeNull();
+    expect(classifyContentRequest('/')).toBeNull();
+  });
+
+  it('ignores .md paths under section names that have no twins', () => {
+    expect(classifyContentRequest('/about/something.md')).toBeNull();
+    expect(classifyContentRequest('/podcast/episode.md')).toBeNull();
+  });
+
+  it('ignores nested and malformed markdown paths', () => {
+    expect(classifyContentRequest('/posts/nested/slug.md')).toBeNull();
+    expect(classifyContentRequest('/posts/.md')).toBeNull();
+    expect(classifyContentRequest('/posts/slug.mdx')).toBeNull();
+  });
+
+  it('lists a matcher for every path it recognises', () => {
+    // The proxy only sees paths its matcher admits, so the two lists drifting
+    // apart means silently uncounted requests.
+    expect([...TRACKED_CONTENT_MATCHERS]).toEqual([
+      '/posts/:slug.md',
+      '/newsletter/:slug.md',
+      '/llms.txt',
+      '/llms-full.txt',
+    ]);
+  });
+});

--- a/src/lib/analytics/content-requests.ts
+++ b/src/lib/analytics/content-requests.ts
@@ -1,0 +1,73 @@
+import type { MarkdownContentType } from '@lib/markdown-export/urls';
+
+import { isMarkdownContentType } from '@lib/markdown-export/urls';
+
+/**
+ * The machine-readable files this site serves alongside its HTML pages. None of
+ * them execute JavaScript, so the analytics snippets that cover the rest of the
+ * site never see a request for one — the proxy is the only place they can be
+ * counted. See src/server/analytics/track-content-request.ts.
+ */
+export type ContentRequestFormat = 'markdown' | 'llms-index' | 'llms-full';
+
+export type TrackedContentRequest = {
+  format: ContentRequestFormat;
+  /** Set for markdown twins; null for the llms.txt files, which span the site. */
+  contentType: MarkdownContentType | null;
+  slug: string | null;
+  /** The public path that was requested, e.g. `/posts/all-about-ch.md`. */
+  path: string;
+};
+
+/**
+ * Proxy matchers covering every path `classifyContentRequest` can match.
+ *
+ * Next.js requires the `matcher` array in src/proxy.ts to be a static literal it
+ * can read without executing the file, so these strings cannot be imported
+ * there. Keep the two lists in sync — a path missing from proxy.ts's matcher is
+ * never routed through the proxy and silently goes uncounted.
+ */
+export const TRACKED_CONTENT_MATCHERS = [
+  '/posts/:slug.md',
+  '/newsletter/:slug.md',
+  '/llms.txt',
+  '/llms-full.txt',
+] as const;
+
+/** `/posts/some-slug.md` and `/newsletter/some-slug.md`, but nothing deeper. */
+const MARKDOWN_TWIN_PATH = /^\/([^/]+)\/([^/]+)\.md$/;
+
+/**
+ * Identify a request for a machine-readable file, or return null for anything
+ * else. Path-only: the proxy matcher has already narrowed the traffic, and this
+ * guards against a matcher that drifts wider than the routes that exist.
+ */
+export const classifyContentRequest = (
+  pathname: string
+): TrackedContentRequest | null => {
+  if (pathname === '/llms.txt') {
+    return {
+      format: 'llms-index',
+      contentType: null,
+      slug: null,
+      path: pathname,
+    };
+  }
+
+  if (pathname === '/llms-full.txt') {
+    return {
+      format: 'llms-full',
+      contentType: null,
+      slug: null,
+      path: pathname,
+    };
+  }
+
+  const match = MARKDOWN_TWIN_PATH.exec(pathname);
+  if (!match) return null;
+
+  const [, type, slug] = match;
+  if (!isMarkdownContentType(type)) return null;
+
+  return { format: 'markdown', contentType: type, slug, path: pathname };
+};

--- a/src/lib/analytics/fathom-beacon.test.ts
+++ b/src/lib/analytics/fathom-beacon.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { buildFathomBeaconUrl, sendFathomPageview } from './fathom-beacon';
+
+const pageview = {
+  siteId: 'ABCDEFGH',
+  origin: 'https://mikebifulco.com',
+  pathname: '/posts/all-about-ch.md',
+  referrer: 'https://chat.openai.com/',
+  userAgent: 'ClaudeBot/1.0',
+};
+
+describe('buildFathomBeaconUrl', () => {
+  it('sends the site, host and path Fathom needs to record a pageview', () => {
+    const url = new URL(buildFathomBeaconUrl(pageview));
+
+    expect(url.origin + url.pathname).toBe('https://cdn.usefathom.com/');
+    expect(url.searchParams.get('sid')).toBe('ABCDEFGH');
+    expect(url.searchParams.get('h')).toBe('https://mikebifulco.com');
+    expect(url.searchParams.get('p')).toBe('/posts/all-about-ch.md');
+    expect(url.searchParams.get('r')).toBe('https://chat.openai.com/');
+    expect(url.searchParams.get('qs')).toBe('{}');
+  });
+
+  it('sends an empty referrer rather than omitting it', () => {
+    const url = new URL(buildFathomBeaconUrl({ ...pageview, referrer: null }));
+
+    expect(url.searchParams.get('r')).toBe('');
+  });
+});
+
+describe('sendFathomPageview', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('forwards the caller user agent and referrer', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('', { status: 200 }));
+
+    await expect(sendFathomPageview(pageview)).resolves.toBe(true);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('sid=ABCDEFGH');
+    expect(init?.headers).toMatchObject({
+      'user-agent': 'ClaudeBot/1.0',
+      referer: 'https://chat.openai.com/',
+    });
+  });
+
+  it('reports a rejected beacon without throwing', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 500 })
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(sendFathomPageview(pageview)).resolves.toBe(false);
+  });
+
+  it('swallows network failures — analytics must not break a request', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(sendFathomPageview(pageview)).resolves.toBe(false);
+  });
+});

--- a/src/lib/analytics/fathom-beacon.ts
+++ b/src/lib/analytics/fathom-beacon.ts
@@ -1,0 +1,88 @@
+/**
+ * Server-side Fathom pageviews.
+ *
+ * Fathom is a browser product: `fathom-client` only queues calls for the script
+ * loaded from cdn.usefathom.com, and the public API at api.usefathom.com is
+ * read-only reporting. Neither can record a request for a file that runs no
+ * JavaScript, which is every markdown twin and llms.txt hit.
+ *
+ * So this sends the same beacon the embed script sends — a GET to the CDN with
+ * the site id and the path — from the proxy instead of from a browser. That
+ * request shape is not part of Fathom's documented API and could change without
+ * notice, so treat it as best-effort: `FATHOM_SERVER_BEACON=off` turns it off
+ * without touching anything else, and a failed beacon never affects the
+ * response (see `sendFathomPageview`).
+ *
+ * To verify after deploying: request a `.md` URL and watch Fathom's real-time
+ * dashboard for the path. To re-derive the parameters if it ever stops
+ * counting, open a page with the embed script and read the request the script
+ * makes to cdn.usefathom.com in devtools.
+ */
+export const FATHOM_BEACON_ENDPOINT = 'https://cdn.usefathom.com/';
+
+export type FathomPageview = {
+  /** Fathom site id (NEXT_PUBLIC_FATHOM_ID). */
+  siteId: string;
+  /** Origin of the request, e.g. `https://mikebifulco.com`. */
+  origin: string;
+  /** Path being recorded, e.g. `/posts/all-about-ch.md`. */
+  pathname: string;
+  /** Referrer from the incoming request, if it sent one. */
+  referrer?: string | null;
+  /**
+   * The requesting client's user agent, forwarded so Fathom attributes the hit
+   * to whoever actually made it rather than to our server. Fathom filters known
+   * bots, so crawler traffic may be dropped on their side by design — PostHog
+   * is where the unfiltered picture lives.
+   */
+  userAgent?: string | null;
+};
+
+export const buildFathomBeaconUrl = ({
+  siteId,
+  origin,
+  pathname,
+  referrer,
+}: FathomPageview): string => {
+  const url = new URL(FATHOM_BEACON_ENDPOINT);
+
+  url.searchParams.set('h', origin);
+  url.searchParams.set('p', pathname);
+  url.searchParams.set('r', referrer ?? '');
+  url.searchParams.set('sid', siteId);
+  // The script sends the page's parsed query string; these files are requested
+  // without one, and a literal empty object matches what it sends in that case.
+  url.searchParams.set('qs', '{}');
+
+  return url.toString();
+};
+
+/**
+ * Fire the beacon. Resolves to whether Fathom accepted it, and never throws —
+ * analytics must not be able to break a page request.
+ */
+export const sendFathomPageview = async (
+  pageview: FathomPageview
+): Promise<boolean> => {
+  try {
+    const response = await fetch(buildFathomBeaconUrl(pageview), {
+      method: 'GET',
+      headers: {
+        ...(pageview.userAgent ? { 'user-agent': pageview.userAgent } : {}),
+        ...(pageview.referrer ? { referer: pageview.referrer } : {}),
+      },
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      console.error(
+        `Fathom beacon for ${pageview.pathname} returned ${response.status}`
+      );
+    }
+
+    return response.ok;
+  } catch (error) {
+    console.error('Failed to send server-side Fathom pageview:', error);
+    return false;
+  }
+};

--- a/src/lib/analytics/user-agent.test.ts
+++ b/src/lib/analytics/user-agent.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyUserAgent } from './user-agent';
+
+describe('classifyUserAgent', () => {
+  it('recognises AI crawlers and in-chat fetchers', () => {
+    const agents = [
+      'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ClaudeBot/1.0; +claudebot@anthropic.com)',
+      'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.2; +https://openai.com/gptbot)',
+      'Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)',
+      'Mozilla/5.0 (compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot)',
+      'Mozilla/5.0 (compatible; CCBot/2.0; +https://commoncrawl.org/faq/)',
+      'meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)',
+    ];
+
+    for (const agent of agents) {
+      expect(classifyUserAgent(agent), agent).toBe('ai-agent');
+    }
+  });
+
+  it('separates generic automation from AI agents', () => {
+    expect(classifyUserAgent('curl/8.7.1')).toBe('bot');
+    expect(classifyUserAgent('python-requests/2.32.3')).toBe('bot');
+    expect(
+      classifyUserAgent(
+        'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+      )
+    ).toBe('bot');
+  });
+
+  it('recognises real browsers', () => {
+    expect(
+      classifyUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15'
+      )
+    ).toBe('browser');
+  });
+
+  it('falls back to unknown for missing or unrecognisable agents', () => {
+    expect(classifyUserAgent(null)).toBe('unknown');
+    expect(classifyUserAgent('')).toBe('unknown');
+    expect(classifyUserAgent('something-bespoke/1.0')).toBe('unknown');
+  });
+});

--- a/src/lib/analytics/user-agent.ts
+++ b/src/lib/analytics/user-agent.ts
@@ -1,0 +1,92 @@
+/**
+ * Coarse classification of who asked for a file. The point of the markdown
+ * twins is to be read by models, so "how much of this traffic is an AI agent
+ * rather than a person" is the number worth breaking these requests down by.
+ *
+ * Deliberately coarse: user agents are self-reported, and a finer taxonomy
+ * would rot faster than it earns its keep.
+ */
+export type AgentCategory = 'ai-agent' | 'bot' | 'browser' | 'unknown';
+
+/**
+ * Crawlers and fetchers that serve LLM training, retrieval or in-chat browsing.
+ * Matched as lowercase substrings.
+ */
+const AI_AGENTS = [
+  'amazonbot',
+  'anthropic-ai',
+  'applebot-extended',
+  'bytespider',
+  'ccbot',
+  'chatgpt-user',
+  'claude-searchbot',
+  'claude-user',
+  'claude-web',
+  'claudebot',
+  'cohere-ai',
+  'cohere-training-data-crawler',
+  'diffbot',
+  'duckassistbot',
+  'facebookbot',
+  'firecrawl',
+  'gptbot',
+  'google-cloudvertexbot',
+  'google-extended',
+  'iaskbot',
+  'img2dataset',
+  'meta-externalagent',
+  'meta-externalfetcher',
+  'mistralai-user',
+  'oai-searchbot',
+  'omgili',
+  'perplexity-user',
+  'perplexitybot',
+  'petalbot',
+  'timpibot',
+  'youbot',
+];
+
+/** Generic automation: search crawlers, scripts, link previewers. */
+const BOT_HINTS = [
+  'bot',
+  'crawl',
+  'spider',
+  'curl',
+  'wget',
+  'headless',
+  'python-requests',
+  'python-urllib',
+  'node-fetch',
+  'axios',
+  'go-http-client',
+  'httpie',
+  'java/',
+  'libwww',
+  'okhttp',
+  'scrapy',
+  'slurp',
+  'feedfetcher',
+  'monitor',
+  'preview',
+];
+
+/** Real browser engines, checked only after the automation lists. */
+const BROWSER_HINTS = ['mozilla/', 'applewebkit', 'gecko/', 'opera'];
+
+export const classifyUserAgent = (
+  userAgent: string | null | undefined
+): AgentCategory => {
+  if (!userAgent) return 'unknown';
+
+  const ua = userAgent.toLowerCase();
+
+  // AI agents first: several of them ("ClaudeBot", "GPTBot") would otherwise be
+  // swallowed by the generic "bot" hint below.
+  if (AI_AGENTS.some((agent) => ua.includes(agent))) return 'ai-agent';
+  if (BOT_HINTS.some((hint) => ua.includes(hint))) return 'bot';
+  // Headless crawlers spoof browser strings, so this is the last check, not the
+  // first — anything reaching here claims to be a browser and nothing else.
+  if (BROWSER_HINTS.some((hint) => ua.includes(hint))) return 'browser';
+
+  return 'unknown';
+};

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from 'next/server';
+import { trackContentRequest } from '@server/analytics/track-content-request';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TRACKED_CONTENT_MATCHERS } from '@lib/analytics/content-requests';
+import { config, proxy } from './proxy';
+
+vi.mock('@server/analytics/track-content-request', () => ({
+  trackContentRequest: vi.fn().mockResolvedValue(undefined),
+}));
+
+const fetchEvent = () =>
+  ({ waitUntil: vi.fn() }) as unknown as Parameters<typeof proxy>[1] & {
+    waitUntil: ReturnType<typeof vi.fn>;
+  };
+
+const requestFor = (
+  path: string,
+  {
+    method = 'GET',
+    headers = {},
+  }: { method?: string; headers?: HeadersInit } = {}
+) =>
+  new NextRequest(new URL(path, 'https://mikebifulco.com'), {
+    method,
+    headers,
+  });
+
+describe('proxy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('matches every path the tracker recognises', () => {
+    // Next.js requires `config.matcher` to be a static literal, so this is what
+    // keeps it honest against the tracked paths.
+    for (const matcher of TRACKED_CONTENT_MATCHERS) {
+      expect(config.matcher).toContain(matcher);
+    }
+  });
+
+  it('tracks a markdown twin request with the caller details', () => {
+    const event = fetchEvent();
+
+    proxy(
+      requestFor('/posts/all-about-ch.md', {
+        headers: {
+          'user-agent': 'ClaudeBot/1.0',
+          referer: 'https://claude.ai/',
+          'x-forwarded-for': '203.0.113.7, 70.41.3.18',
+        },
+      }),
+      event
+    );
+
+    expect(event.waitUntil).toHaveBeenCalledTimes(1);
+    expect(trackContentRequest).toHaveBeenCalledWith(
+      {
+        format: 'markdown',
+        contentType: 'posts',
+        slug: 'all-about-ch',
+        path: '/posts/all-about-ch.md',
+      },
+      {
+        origin: 'https://mikebifulco.com',
+        userAgent: 'ClaudeBot/1.0',
+        referrer: 'https://claude.ai/',
+        // The client, not the proxy hops behind it.
+        ip: '203.0.113.7',
+      }
+    );
+  });
+
+  it('tracks llms.txt requests', () => {
+    proxy(requestFor('/llms-full.txt'), fetchEvent());
+
+    expect(trackContentRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ format: 'llms-full' }),
+      expect.anything()
+    );
+  });
+
+  it('ignores html pages and non-GET requests', () => {
+    proxy(requestFor('/posts/all-about-ch'), fetchEvent());
+    proxy(
+      requestFor('/posts/all-about-ch.md', { method: 'POST' }),
+      fetchEvent()
+    );
+
+    expect(trackContentRequest).not.toHaveBeenCalled();
+  });
+
+  it('still redirects pagination routes', () => {
+    const response = proxy(requestFor('/page/1'), fetchEvent());
+
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get('location')).toBe('https://mikebifulco.com/');
+    expect(trackContentRequest).not.toHaveBeenCalled();
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,9 +1,36 @@
-import type { NextRequest } from 'next/server';
+import type { NextFetchEvent, NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { trackContentRequest } from '@server/analytics/track-content-request';
 
+import { classifyContentRequest } from '@lib/analytics/content-requests';
 import { handlePaginationRedirects } from './utils/pagination-redirects';
 
-export function proxy(request: NextRequest) {
+/** First value of X-Forwarded-For — the client, before any proxy hops. */
+const clientIpFrom = (request: NextRequest): string | null =>
+  request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+  request.headers.get('x-real-ip');
+
+export function proxy(request: NextRequest, event: NextFetchEvent) {
+  // Markdown twins and llms.txt are static files that run no JavaScript, so the
+  // PostHog and Fathom snippets on the site never see a request for one. The
+  // proxy is the only place they can be counted.
+  const contentRequest =
+    request.method === 'GET'
+      ? classifyContentRequest(request.nextUrl.pathname)
+      : null;
+
+  if (contentRequest) {
+    // waitUntil: the reader gets the file without waiting on analytics.
+    event.waitUntil(
+      trackContentRequest(contentRequest, {
+        origin: request.nextUrl.origin,
+        userAgent: request.headers.get('user-agent'),
+        referrer: request.headers.get('referer'),
+        ip: clientIpFrom(request),
+      })
+    );
+  }
+
   // Handle pagination redirects using centralized logic
   const paginationRedirect = handlePaginationRedirects(request);
   if (paginationRedirect) {
@@ -16,5 +43,15 @@ export function proxy(request: NextRequest) {
 export const config = {
   // Note: This matcher array must be a static literal in this file for Next.js static analysis to work
   // If you update pagination routes, also update PAGINATION_MIDDLEWARE_MATCHERS in src/utils/pagination-redirects.ts for consistency.
-  matcher: ['/page/:path*', '/newsletter/page/:path*'],
+  // The markdown/llms.txt entries mirror TRACKED_CONTENT_MATCHERS in
+  // src/lib/analytics/content-requests.ts — a path missing here is never routed
+  // through the proxy and goes uncounted.
+  matcher: [
+    '/page/:path*',
+    '/newsletter/page/:path*',
+    '/posts/:slug.md',
+    '/newsletter/:slug.md',
+    '/llms.txt',
+    '/llms-full.txt',
+  ],
 };

--- a/src/server/analytics/track-content-request.test.ts
+++ b/src/server/analytics/track-content-request.test.ts
@@ -1,0 +1,179 @@
+import type { TrackedContentRequest } from '@lib/analytics/content-requests';
+import { captureServerEvent } from '@server/posthog';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sendFathomPageview } from '@lib/analytics/fathom-beacon';
+import {
+  MARKDOWN_PAGE_VIEW_EVENT,
+  trackContentRequest,
+} from './track-content-request';
+
+// Mutable so each test can set the deployment environment and kill switches.
+const mockEnv = vi.hoisted(() => ({
+  NEXT_PUBLIC_FATHOM_ID: 'ABCDEFGH',
+  VERCEL_ENV: 'production' as string | undefined,
+  SERVER_ANALYTICS: 'auto' as 'auto' | 'on' | 'off',
+  FATHOM_SERVER_BEACON: 'on' as 'on' | 'off',
+}));
+
+vi.mock('@utils/env', () => ({ env: mockEnv }));
+vi.mock('@server/posthog', () => ({ captureServerEvent: vi.fn() }));
+vi.mock('@lib/analytics/fathom-beacon', () => ({
+  sendFathomPageview: vi.fn().mockResolvedValue(true),
+}));
+
+const markdownRequest: TrackedContentRequest = {
+  format: 'markdown',
+  contentType: 'posts',
+  slug: 'all-about-ch',
+  path: '/posts/all-about-ch.md',
+};
+
+const context = {
+  origin: 'https://mikebifulco.com',
+  userAgent: 'Mozilla/5.0 (compatible; ClaudeBot/1.0)',
+  referrer: null,
+  ip: '203.0.113.7',
+};
+
+describe('trackContentRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.VERCEL_ENV = 'production';
+    mockEnv.SERVER_ANALYTICS = 'auto';
+    mockEnv.FATHOM_SERVER_BEACON = 'on';
+  });
+
+  it('records the request in both PostHog and Fathom', async () => {
+    await trackContentRequest(markdownRequest, context);
+
+    expect(captureServerEvent).toHaveBeenCalledTimes(1);
+    expect(captureServerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: MARKDOWN_PAGE_VIEW_EVENT,
+        properties: expect.objectContaining({
+          format: 'markdown',
+          content_type: 'posts',
+          slug: 'all-about-ch',
+          path: '/posts/all-about-ch.md',
+          agent_category: 'ai-agent',
+          $current_url: 'https://mikebifulco.com/posts/all-about-ch.md',
+          $host: 'mikebifulco.com',
+        }),
+      })
+    );
+
+    expect(sendFathomPageview).toHaveBeenCalledWith({
+      siteId: 'ABCDEFGH',
+      origin: 'https://mikebifulco.com',
+      pathname: '/posts/all-about-ch.md',
+      referrer: null,
+      userAgent: context.userAgent,
+    });
+  });
+
+  it('keeps person profiles and server geolocation out of PostHog', async () => {
+    await trackContentRequest(markdownRequest, context);
+
+    const [{ properties }] = vi.mocked(captureServerEvent).mock.calls[0];
+    expect(properties).toMatchObject({
+      $process_person_profile: false,
+      $geoip_disable: true,
+    });
+  });
+
+  it('identifies callers pseudonymously, never by raw IP', async () => {
+    await trackContentRequest(markdownRequest, context);
+    const [first] = vi.mocked(captureServerEvent).mock.calls[0];
+
+    await trackContentRequest(markdownRequest, context);
+    const [repeat] = vi.mocked(captureServerEvent).mock.calls[1];
+
+    await trackContentRequest(markdownRequest, {
+      ...context,
+      ip: '198.51.100.4',
+    });
+    const [other] = vi.mocked(captureServerEvent).mock.calls[2];
+
+    expect(first.distinctId).toMatch(/^md-reader:[0-9a-f]{32}$/);
+    expect(first.distinctId).toBe(repeat.distinctId);
+    expect(first.distinctId).not.toBe(other.distinctId);
+    expect(JSON.stringify(first)).not.toContain('203.0.113.7');
+  });
+
+  it('tags the llms.txt files by format', async () => {
+    await trackContentRequest(
+      {
+        format: 'llms-full',
+        contentType: null,
+        slug: null,
+        path: '/llms-full.txt',
+      },
+      context
+    );
+
+    expect(captureServerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          format: 'llms-full',
+          content_type: null,
+          path: '/llms-full.txt',
+        }),
+      })
+    );
+  });
+
+  it('stays quiet outside production by default', async () => {
+    mockEnv.VERCEL_ENV = 'preview';
+
+    await trackContentRequest(markdownRequest, context);
+
+    expect(captureServerEvent).not.toHaveBeenCalled();
+    expect(sendFathomPageview).not.toHaveBeenCalled();
+  });
+
+  it('can be forced on for a preview deploy', async () => {
+    mockEnv.VERCEL_ENV = 'preview';
+    mockEnv.SERVER_ANALYTICS = 'on';
+
+    await trackContentRequest(markdownRequest, context);
+
+    expect(captureServerEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('can be turned off entirely', async () => {
+    mockEnv.SERVER_ANALYTICS = 'off';
+
+    await trackContentRequest(markdownRequest, context);
+
+    expect(captureServerEvent).not.toHaveBeenCalled();
+    expect(sendFathomPageview).not.toHaveBeenCalled();
+  });
+
+  it('keeps PostHog running when the Fathom beacon is disabled', async () => {
+    mockEnv.FATHOM_SERVER_BEACON = 'off';
+
+    await trackContentRequest(markdownRequest, context);
+
+    expect(captureServerEvent).toHaveBeenCalledTimes(1);
+    expect(sendFathomPageview).not.toHaveBeenCalled();
+  });
+
+  it('never rejects, so a bad request cannot break waitUntil', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      trackContentRequest(markdownRequest, { ...context, origin: 'not-a-url' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('still reports to Fathom when PostHog capture fails', async () => {
+    vi.mocked(captureServerEvent).mockRejectedValueOnce(new Error('down'));
+
+    await expect(
+      trackContentRequest(markdownRequest, context)
+    ).resolves.toBeUndefined();
+
+    expect(sendFathomPageview).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/analytics/track-content-request.test.ts
+++ b/src/server/analytics/track-content-request.test.ts
@@ -1,6 +1,6 @@
 import type { TrackedContentRequest } from '@lib/analytics/content-requests';
 import { captureServerEvent } from '@server/posthog';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { sendFathomPageview } from '@lib/analytics/fathom-beacon';
 import {
@@ -42,6 +42,11 @@ describe('trackContentRequest', () => {
     mockEnv.VERCEL_ENV = 'production';
     mockEnv.SERVER_ANALYTICS = 'auto';
     mockEnv.FATHOM_SERVER_BEACON = 'on';
+  });
+
+  // A console spy left in place would silence errors in every test after it.
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('records the request in both PostHog and Fathom', async () => {

--- a/src/server/analytics/track-content-request.ts
+++ b/src/server/analytics/track-content-request.ts
@@ -36,10 +36,12 @@ const serverAnalyticsEnabled = (): boolean => {
 };
 
 /**
- * A stable id for grouping a single caller's requests without storing anything
- * identifying: the IP and user agent are hashed and the raw values never leave
- * the proxy. PostHog person profiles stay off for these events (see
- * `$process_person_profile` below), so this id only ever groups events.
+ * A stable id for grouping a single caller's requests: the IP and user agent
+ * are hashed together, and the raw IP never leaves the proxy. (The user agent
+ * itself is sent on, as `$raw_user_agent` — it is what tells ClaudeBot apart
+ * from GPTBot, which is the point of counting these requests.) PostHog person
+ * profiles stay off for these events (see `$process_person_profile` below), so
+ * this id only ever groups events.
  */
 const distinctIdFor = ({ ip, userAgent }: ContentRequestContext): string => {
   const fingerprint = `${ip ?? 'unknown-ip'}|${userAgent ?? 'unknown-ua'}`;

--- a/src/server/analytics/track-content-request.ts
+++ b/src/server/analytics/track-content-request.ts
@@ -1,0 +1,108 @@
+import { createHash } from 'node:crypto';
+import type { TrackedContentRequest } from '@lib/analytics/content-requests';
+import { captureServerEvent } from '@server/posthog';
+
+import { sendFathomPageview } from '@lib/analytics/fathom-beacon';
+import { classifyUserAgent } from '@lib/analytics/user-agent';
+import { env } from '@utils/env';
+
+/**
+ * One event covers every machine-readable format; break it down by the `format`
+ * property. Named to sit alongside the `markdown_copy_content`,
+ * `markdown_copy_link` and `markdown_open` events the Copy as Markdown control
+ * sends from the browser.
+ */
+export const MARKDOWN_PAGE_VIEW_EVENT = 'markdown_page_view';
+
+/** What the proxy knows about the caller, extracted from the request. */
+export type ContentRequestContext = {
+  /** Origin the file was requested from, e.g. `https://mikebifulco.com`. */
+  origin: string;
+  userAgent: string | null;
+  referrer: string | null;
+  /** Client IP, used only to derive a pseudonymous id — never sent onward. */
+  ip: string | null;
+};
+
+/**
+ * Enabled on production deployments only by default, so previews and `next dev`
+ * do not pollute the numbers. `SERVER_ANALYTICS=on` forces it on (useful for
+ * checking a preview deploy end to end), `off` disables it everywhere.
+ */
+const serverAnalyticsEnabled = (): boolean => {
+  if (env.SERVER_ANALYTICS === 'off') return false;
+  if (env.SERVER_ANALYTICS === 'on') return true;
+  return env.VERCEL_ENV === 'production';
+};
+
+/**
+ * A stable id for grouping a single caller's requests without storing anything
+ * identifying: the IP and user agent are hashed and the raw values never leave
+ * the proxy. PostHog person profiles stay off for these events (see
+ * `$process_person_profile` below), so this id only ever groups events.
+ */
+const distinctIdFor = ({ ip, userAgent }: ContentRequestContext): string => {
+  const fingerprint = `${ip ?? 'unknown-ip'}|${userAgent ?? 'unknown-ua'}`;
+  const hash = createHash('sha256').update(fingerprint).digest('hex');
+
+  return `md-reader:${hash.slice(0, 32)}`;
+};
+
+/**
+ * Record a request for a markdown twin or llms.txt file in both analytics
+ * services. Never throws and never blocks the response — the proxy hands this
+ * to `event.waitUntil`, and each service's failures are swallowed by the
+ * capture helpers themselves.
+ */
+export const trackContentRequest = async (
+  contentRequest: TrackedContentRequest,
+  context: ContentRequestContext
+): Promise<void> => {
+  if (!serverAnalyticsEnabled()) return;
+
+  const { format, contentType, slug, path } = contentRequest;
+  const { origin, userAgent, referrer } = context;
+
+  try {
+    const postHogCapture = captureServerEvent({
+      distinctId: distinctIdFor(context),
+      event: MARKDOWN_PAGE_VIEW_EVENT,
+      properties: {
+        format,
+        content_type: contentType,
+        slug,
+        path,
+        agent_category: classifyUserAgent(userAgent),
+        $current_url: `${origin}${path}`,
+        $host: new URL(origin).host,
+        $pathname: path,
+        $referrer: referrer,
+        $raw_user_agent: userAgent,
+        // These requests are overwhelmingly crawlers, and a person profile per
+        // crawler fingerprint would be noise with a bill attached.
+        $process_person_profile: false,
+        // Without this PostHog would geolocate our own server, not the caller.
+        $geoip_disable: true,
+      },
+    });
+
+    const fathomCapture =
+      env.FATHOM_SERVER_BEACON === 'off'
+        ? Promise.resolve(false)
+        : sendFathomPageview({
+            siteId: env.NEXT_PUBLIC_FATHOM_ID,
+            origin,
+            pathname: path,
+            referrer,
+            userAgent,
+          });
+
+    // One slow or failing service must not hold up the other.
+    await Promise.allSettled([postHogCapture, fathomCapture]);
+  } catch (error) {
+    // Belt and braces: both capture helpers swallow their own failures, so this
+    // is only reachable if a malformed request gets this far. Either way an
+    // analytics problem must not surface as a rejected `waitUntil` promise.
+    console.error('Failed to track a machine-readable page view:', error);
+  }
+};

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -32,6 +32,13 @@ export const env = createEnv({
     TURNSTILE_SECRET_KEY: isVercelProduction
       ? z.string().min(1)
       : z.string().default(TURNSTILE_TEST_SECRET_KEY),
+    // Server-side analytics for files with no client-side JS (markdown twins,
+    // llms.txt) — see src/server/analytics/track-content-request.ts.
+    // 'auto' limits it to production so previews and dev do not skew the data.
+    SERVER_ANALYTICS: z.enum(['auto', 'on', 'off']).default('auto'),
+    // Kill switch for the server-side Fathom beacon specifically, which relies
+    // on Fathom's undocumented request shape. 'off' leaves PostHog untouched.
+    FATHOM_SERVER_BEACON: z.enum(['on', 'off']).default('on'),
   },
   client: {
     NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME: z.string().min(1),


### PR DESCRIPTION
The markdown twins and llms.txt files are static text served with no client-side JS, so the PostHog and Fathom snippets that cover the rest of the site never saw a request for one. Every direct hit — crawler, curl, or a reader following "Open .md" — went uncounted, and the route handler is force-static so it runs at build time, not per request.

The proxy is the one place these requests can be observed, so it now records them there:

- PostHog gets a `markdown_page_view` event per request, with the format, content type, slug, path and a coarse agent category so LLM crawler traffic can be told apart from people. Person profiles and server-side geolocation are off, and the caller is identified by a hash of IP and user agent rather than the values themselves.
- Fathom has no documented server-side ingest, so it gets the same beacon its embed script sends, forwarding the caller's user agent. That request shape is undocumented, so FATHOM_SERVER_BEACON=off disables it on its own.

Tracking runs on production deployments only by default (SERVER_ANALYTICS controls it), happens in waitUntil so readers never wait on it, and swallows its own failures.
