### PR TITLE
Add a Google preferred sources button to the footer

### DIFF
--- a/.posthog-events.json
+++ b/.posthog-events.json
@@ -10,6 +10,11 @@
     "file_path": "src/components/SponsorCTA/SponsorCTA.tsx"
   },
   {
+    "event_name": "preferred_source_clicked",
+    "event_description": "User clicked the footer button to add mikebifulco.com as a Google preferred source (in_page_flow distinguishes Google's in-page flow from the deeplink fallback)",
+    "file_path": "src/components/PreferredSource/PreferredSource.tsx"
+  },
+  {
     "event_name": "post_read_started",
     "event_description": "User started reading a blog post (top of conversion funnel for content engagement)",
     "file_path": "src/pages/posts/[slug].tsx"

--- a/src/components/PreferredSource/PreferredSource.test.tsx
+++ b/src/components/PreferredSource/PreferredSource.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import posthog from 'posthog-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import PreferredSource from './PreferredSource';
+
+vi.mock('posthog-js', () => ({
+  default: { capture: vi.fn() },
+}));
+
+// next/script renders nothing useful in jsdom, and loading Google's library is
+// exactly what these tests stand in for.
+vi.mock('next/script', () => ({
+  default: () => null,
+}));
+
+type QueueCallback = (api: {
+  init: (options: unknown) => void;
+  addPreferredSource: () => void;
+}) => void;
+
+const getQueue = () =>
+  globalThis.PREFERRED_SOURCE as unknown as QueueCallback[] | undefined;
+
+const link = () =>
+  screen.getByRole('link', {
+    name: /make mikebifulco\.com a preferred source/i,
+  });
+
+describe('PreferredSource', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete (globalThis as { PREFERRED_SOURCE?: unknown }).PREFERRED_SOURCE;
+  });
+
+  it('links to the source preferences deeplink for this site', () => {
+    render(<PreferredSource />);
+
+    expect(link()).toHaveAttribute(
+      'href',
+      'https://www.google.com/preferences/source?q=mikebifulco.com'
+    );
+  });
+
+  it('queues an initialization callback for Google’s library', () => {
+    render(<PreferredSource />);
+
+    expect(getQueue()).toHaveLength(1);
+  });
+
+  it('follows the deeplink while the library has not loaded', () => {
+    render(<PreferredSource />);
+
+    const notPrevented = fireEvent.click(link());
+
+    expect(notPrevented).toBe(true);
+    expect(posthog.capture).toHaveBeenCalledWith('preferred_source_clicked', {
+      in_page_flow: false,
+    });
+  });
+
+  it('opens the in-page flow once the library has loaded', () => {
+    render(<PreferredSource />);
+
+    const init = vi.fn();
+    const addPreferredSource = vi.fn();
+    // Stand in for the library draining the queue on load.
+    getQueue()?.forEach((callback) => callback({ init, addPreferredSource }));
+
+    expect(init).toHaveBeenCalledWith({ theme: 'light' });
+
+    const notPrevented = fireEvent.click(link());
+
+    expect(addPreferredSource).toHaveBeenCalledTimes(1);
+    expect(notPrevented).toBe(false); // default prevented, so no navigation
+    expect(posthog.capture).toHaveBeenCalledWith('preferred_source_clicked', {
+      in_page_flow: true,
+    });
+  });
+});

--- a/src/components/PreferredSource/PreferredSource.test.tsx
+++ b/src/components/PreferredSource/PreferredSource.test.tsx
@@ -2,25 +2,27 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import posthog from 'posthog-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import PreferredSource from './PreferredSource';
-
 vi.mock('posthog-js', () => ({
   default: { capture: vi.fn() },
 }));
 
-// next/script renders nothing useful in jsdom, and loading Google's library is
-// exactly what these tests stand in for.
+// jsdom can't load Google's script; the tests drive the queue directly.
 vi.mock('next/script', () => ({
   default: () => null,
 }));
 
-type QueueCallback = (api: {
-  init: (options: unknown) => void;
-  addPreferredSource: () => void;
-}) => void;
+/** Registration happens once per module load, so each test gets a fresh one. */
+const loadButton = async () => {
+  vi.resetModules();
 
-const getQueue = () =>
-  globalThis.PREFERRED_SOURCE as unknown as QueueCallback[] | undefined;
+  return (await import('./PreferredSource')).default;
+};
+
+const renderButton = async () => {
+  const PreferredSource = await loadButton();
+
+  render(<PreferredSource />);
+};
 
 const link = () =>
   screen.getByRole('link', {
@@ -30,11 +32,11 @@ const link = () =>
 describe('PreferredSource', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    delete (globalThis as { PREFERRED_SOURCE?: unknown }).PREFERRED_SOURCE;
+    delete globalThis.PREFERRED_SOURCE;
   });
 
-  it('links to the source preferences deeplink for this site', () => {
-    render(<PreferredSource />);
+  it('links to the source preferences deeplink for this site', async () => {
+    await renderButton();
 
     expect(link()).toHaveAttribute(
       'href',
@@ -42,14 +44,8 @@ describe('PreferredSource', () => {
     );
   });
 
-  it('queues an initialization callback for Google’s library', () => {
-    render(<PreferredSource />);
-
-    expect(getQueue()).toHaveLength(1);
-  });
-
-  it('follows the deeplink while the library has not loaded', () => {
-    render(<PreferredSource />);
+  it('follows the deeplink while the library has not loaded', async () => {
+    await renderButton();
 
     const notPrevented = fireEvent.click(link());
 
@@ -59,13 +55,15 @@ describe('PreferredSource', () => {
     });
   });
 
-  it('opens the in-page flow once the library has loaded', () => {
-    render(<PreferredSource />);
+  it('opens the in-page flow once the library has loaded', async () => {
+    await renderButton();
 
     const init = vi.fn();
     const addPreferredSource = vi.fn();
     // Stand in for the library draining the queue on load.
-    getQueue()?.forEach((callback) => callback({ init, addPreferredSource }));
+    globalThis.PREFERRED_SOURCE?.forEach((callback) =>
+      callback({ init, addPreferredSource })
+    );
 
     expect(init).toHaveBeenCalledWith({ theme: 'light' });
 
@@ -76,5 +74,14 @@ describe('PreferredSource', () => {
     expect(posthog.capture).toHaveBeenCalledWith('preferred_source_clicked', {
       in_page_flow: true,
     });
+  });
+
+  it('queues one callback no matter how many times it mounts', async () => {
+    const PreferredSource = await loadButton();
+
+    render(<PreferredSource />).unmount();
+    render(<PreferredSource />);
+
+    expect(globalThis.PREFERRED_SOURCE).toHaveLength(1);
   });
 });

--- a/src/components/PreferredSource/PreferredSource.tsx
+++ b/src/components/PreferredSource/PreferredSource.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import Script from 'next/script';
 import posthog from 'posthog-js';
 
 import { GoogleIcon } from '@components/icons';
+import Link from '@components/Link';
 import { BASE_SITE_URL } from '@/config';
 
 type PreferredSourceApi = {
@@ -12,68 +13,48 @@ type PreferredSourceApi = {
   addPreferredSource: () => void;
 };
 
-type PreferredSourceCallback = (api: PreferredSourceApi) => void;
-
-/** Google's library replaces the queue array with a live object of this shape. */
-type PreferredSourceQueue = {
-  push: (callback: PreferredSourceCallback) => void;
-};
-
 declare global {
-  var PREFERRED_SOURCE: PreferredSourceQueue | undefined;
+  // Google's library drains this queue on load, then replaces it with an
+  // object whose push runs callbacks immediately.
+  var PREFERRED_SOURCE: ((api: PreferredSourceApi) => void)[] | undefined;
 }
 
 const SITE_DOMAIN = new URL(BASE_SITE_URL).hostname;
-
-/**
- * Where the button sends readers when Google's library never loads (blocked
- * script, no JS): the same source preferences tool, just as a full page.
- */
 const DEEPLINK = `https://www.google.com/preferences/source?q=${SITE_DOMAIN}`;
 
-/**
- * Lets readers mark this site as a preferred source in Google Search, which
- * makes its posts more likely to surface in Top Stories and AI Overviews for
- * them. Google's own library renders an in-page flow that returns readers
- * where they left off, so the button asks for it when it has loaded and falls
- * back to the deeplink when it hasn't.
- *
- * @see https://developers.google.com/search/docs/appearance/preferred-sources
- */
+// One library instance per page load, so registration is module state rather
+// than component state — a remount must not queue a second callback.
+let api: PreferredSourceApi | null = null;
+let registered = false;
+
+const register = () => {
+  if (registered) return;
+  registered = true;
+
+  (globalThis.PREFERRED_SOURCE ??= []).push((preferredSource) => {
+    preferredSource.init({ theme: 'light' });
+    api = preferredSource;
+  });
+};
+
+/** @see https://developers.google.com/search/docs/appearance/preferred-sources */
 const PreferredSource = () => {
-  const api = useRef<PreferredSourceApi | null>(null);
-
-  useEffect(() => {
-    // The queue is drained when Google's library loads; pushing before then is
-    // the documented way to hand it options, and a push after it has loaded
-    // runs immediately. Either order works, so registration doesn't wait on
-    // the script.
-    const queue: PreferredSourceQueue =
-      globalThis.PREFERRED_SOURCE ?? new Array<PreferredSourceCallback>();
-    globalThis.PREFERRED_SOURCE = queue;
-
-    queue.push((preferredSource) => {
-      preferredSource.init({ theme: 'light' });
-      api.current = preferredSource;
-    });
-  }, []);
+  useEffect(register, []);
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     posthog.capture('preferred_source_clicked', {
-      // Distinguishes the in-page flow from the deeplink fallback.
-      in_page_flow: Boolean(api.current),
+      in_page_flow: Boolean(api),
     });
 
-    if (!api.current) return; // let the browser follow the deeplink
+    if (!api) return; // let the browser follow the deeplink
 
     event.preventDefault();
-    api.current.addPreferredSource();
+    api.addPreferredSource();
   };
 
   return (
     <>
-      {/* "manual" keeps the library from rendering its own button, so the one
-          below stays in the site's voice. */}
+      {/* "manual": don't render Google's own button. */}
       <Script
         id="google-preferred-sources"
         src="https://news.google.com/swg/js/v1/publisher.js"
@@ -81,19 +62,19 @@ const PreferredSource = () => {
         preferred-sources-control="manual"
       />
 
-      <a
+      <Link
         href={DEEPLINK}
         target="_blank"
         rel="noopener noreferrer"
         onClick={handleClick}
         className="inline-flex w-fit items-center gap-2 rounded-full border border-pink-200 bg-white px-3 py-1.5 text-sm text-black shadow-sm transition-all duration-200 hover:scale-105 hover:border-pink-600 hover:text-pink-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-400"
       >
-        <GoogleIcon aria-hidden />
+        <GoogleIcon />
         <span>
           Make <span className="font-bold">{SITE_DOMAIN}</span> a preferred
           source
         </span>
-      </a>
+      </Link>
     </>
   );
 };

--- a/src/components/PreferredSource/PreferredSource.tsx
+++ b/src/components/PreferredSource/PreferredSource.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import Script from 'next/script';
+import posthog from 'posthog-js';
+
+import { GoogleIcon } from '@components/icons';
+import { BASE_SITE_URL } from '@/config';
+
+type PreferredSourceApi = {
+  init: (options: { theme?: 'light' | 'dark'; lang?: string }) => void;
+  addPreferredSource: () => void;
+};
+
+type PreferredSourceCallback = (api: PreferredSourceApi) => void;
+
+/** Google's library replaces the queue array with a live object of this shape. */
+type PreferredSourceQueue = {
+  push: (callback: PreferredSourceCallback) => void;
+};
+
+declare global {
+  var PREFERRED_SOURCE: PreferredSourceQueue | undefined;
+}
+
+const SITE_DOMAIN = new URL(BASE_SITE_URL).hostname;
+
+/**
+ * Where the button sends readers when Google's library never loads (blocked
+ * script, no JS): the same source preferences tool, just as a full page.
+ */
+const DEEPLINK = `https://www.google.com/preferences/source?q=${SITE_DOMAIN}`;
+
+/**
+ * Lets readers mark this site as a preferred source in Google Search, which
+ * makes its posts more likely to surface in Top Stories and AI Overviews for
+ * them. Google's own library renders an in-page flow that returns readers
+ * where they left off, so the button asks for it when it has loaded and falls
+ * back to the deeplink when it hasn't.
+ *
+ * @see https://developers.google.com/search/docs/appearance/preferred-sources
+ */
+const PreferredSource = () => {
+  const api = useRef<PreferredSourceApi | null>(null);
+
+  useEffect(() => {
+    // The queue is drained when Google's library loads; pushing before then is
+    // the documented way to hand it options, and a push after it has loaded
+    // runs immediately. Either order works, so registration doesn't wait on
+    // the script.
+    const queue: PreferredSourceQueue =
+      globalThis.PREFERRED_SOURCE ?? new Array<PreferredSourceCallback>();
+    globalThis.PREFERRED_SOURCE = queue;
+
+    queue.push((preferredSource) => {
+      preferredSource.init({ theme: 'light' });
+      api.current = preferredSource;
+    });
+  }, []);
+
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    posthog.capture('preferred_source_clicked', {
+      // Distinguishes the in-page flow from the deeplink fallback.
+      in_page_flow: Boolean(api.current),
+    });
+
+    if (!api.current) return; // let the browser follow the deeplink
+
+    event.preventDefault();
+    api.current.addPreferredSource();
+  };
+
+  return (
+    <>
+      {/* "manual" keeps the library from rendering its own button, so the one
+          below stays in the site's voice. */}
+      <Script
+        id="google-preferred-sources"
+        src="https://news.google.com/swg/js/v1/publisher.js"
+        strategy="lazyOnload"
+        preferred-sources-control="manual"
+      />
+
+      <a
+        href={DEEPLINK}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={handleClick}
+        className="inline-flex w-fit items-center gap-2 rounded-full border border-pink-200 bg-white px-3 py-1.5 text-sm text-black shadow-sm transition-all duration-200 hover:scale-105 hover:border-pink-600 hover:text-pink-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-pink-400"
+      >
+        <GoogleIcon aria-hidden />
+        <span>
+          Make <span className="font-bold">{SITE_DOMAIN}</span> a preferred
+          source
+        </span>
+      </a>
+    </>
+  );
+};
+
+export default PreferredSource;

--- a/src/components/PreferredSource/index.ts
+++ b/src/components/PreferredSource/index.ts
@@ -1,0 +1,1 @@
+export { default as PreferredSource } from './PreferredSource';

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,4 +1,5 @@
 import Link from '@components/Link';
+import { PreferredSource } from '@components/PreferredSource';
 import config from '../config';
 import RelatedContentLinksByTag from './RelatedContent/RelatedContentLinksByTag';
 import { SocialLinks } from './SocialLinks';
@@ -23,6 +24,7 @@ const Footer = () => {
             <span>© 2019-{new Date().getFullYear()} Mike Bifulco</span>
 
             <SponsorCTA />
+            <PreferredSource />
             <SocialLinks />
           </div>
 

--- a/src/components/icons/GoogleIcon.tsx
+++ b/src/components/icons/GoogleIcon.tsx
@@ -2,10 +2,10 @@ import type { Icon } from '.';
 
 import clsxm from '@utils/clsxm';
 
-/** Google's four-color "G" mark, kept in brand colors rather than currentColor. */
-const GoogleIcon: Icon = ({ className, ...props }) => (
+const GoogleIcon: Icon = ({ className }) => (
   <svg
-    {...props}
+    aria-hidden="true"
+    focusable="false"
     viewBox="0 0 48 48"
     preserveAspectRatio="xMidYMid meet"
     style={{ verticalAlign: 'middle' }}

--- a/src/components/icons/GoogleIcon.tsx
+++ b/src/components/icons/GoogleIcon.tsx
@@ -1,0 +1,33 @@
+import type { Icon } from '.';
+
+import clsxm from '@utils/clsxm';
+
+/** Google's four-color "G" mark, kept in brand colors rather than currentColor. */
+const GoogleIcon: Icon = ({ className, ...props }) => (
+  <svg
+    {...props}
+    viewBox="0 0 48 48"
+    preserveAspectRatio="xMidYMid meet"
+    style={{ verticalAlign: 'middle' }}
+    className={clsxm('h-4 w-4', className)}
+  >
+    <path
+      fill="#4285F4"
+      d="M45.12 24.5c0-1.56-.14-3.06-.4-4.5H24v8.51h11.84c-.51 2.75-2.06 5.08-4.39 6.64v5.52h7.11c4.16-3.83 6.56-9.47 6.56-16.17z"
+    />
+    <path
+      fill="#34A853"
+      d="M24 46c5.94 0 10.92-1.97 14.56-5.33l-7.11-5.52c-1.97 1.32-4.49 2.1-7.45 2.1-5.73 0-10.58-3.87-12.31-9.07H4.34v5.7C7.96 41.07 15.4 46 24 46z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M11.69 28.18c-.44-1.32-.69-2.73-.69-4.18s.25-2.86.69-4.18v-5.7H4.34C2.85 17.09 2 20.45 2 24s.85 6.91 2.34 9.88l7.35-5.7z"
+    />
+    <path
+      fill="#EA4335"
+      d="M24 10.75c3.23 0 6.13 1.11 8.41 3.29l6.31-6.31C34.91 4.18 29.93 2 24 2 15.4 2 7.96 6.93 4.34 14.12l7.35 5.7c1.73-5.2 6.58-9.07 12.31-9.07z"
+    />
+  </svg>
+);
+
+export default GoogleIcon;

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -4,6 +4,7 @@ export type Icon = React.FC<IconProps>;
 
 export { default as BlueskyIcon } from './BlueskyIcon';
 export { default as GitHubIcon } from './GitHubIcon';
+export { default as GoogleIcon } from './GoogleIcon';
 export { default as MastodonIcon } from './MastodonIcon';
 export { default as PatreonIcon } from './PatreonIcon';
 export { default as RssIcon } from './RssIcon';


### PR DESCRIPTION
Readers who mark the site as a preferred source in Google Search are more
likely to see its posts in Top Stories, AI Mode, and AI Overviews.

The button is styled in the site's own voice rather than using Google's
rendered badge: the library loads with preferred-sources-control="manual"
so it renders nothing, and the button calls addPreferredSource() to open
the in-page flow, which returns readers where they left off. When the
library hasn't loaded — blocked script, no JS — the anchor falls through
to Google's source preferences deeplink for the same result.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X7J68EYP77grq5uMp2aq3s